### PR TITLE
Spoiler rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .venv
+
+# no need to share the IDE configuration files
+.idea

--- a/content-script.js
+++ b/content-script.js
@@ -1,14 +1,12 @@
-//
-// https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts
-//
+// Content Script
+// https://developer.chrome.com/docs/extensions/mv3/content_scripts/
 
 let oldHref = document.location.href
 
+// Inject comentario.js
 const script = document.createElement("script")
 script.src = chrome.runtime.getURL("comentario.js")
 script.defer = true
-
-const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay))
 
 const appendScript = () => {
 	if (document.head) {
@@ -20,20 +18,196 @@ const appendScript = () => {
 
 appendScript()
 
+const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay))
+
+// Wait for an element matching the selector to appear
+const getBodyElementEventually = async function (selector) {
+	return new Promise((resolve) => {
+		function resolveIfPresent() {
+			const elem = document.querySelector(selector)
+			if (elem !== null) {
+				resolve(elem)
+			} else {
+				requestAnimationFrame(resolveIfPresent)
+			}
+		}
+		resolveIfPresent()
+	})
+}
+
+// Unified replacement function for spoilers and timestamps
+const replaceFeaturesWithHtml = function (commentHolder) {
+	const spoilerRegex = /\|\|.*?\|\|/g
+	const timestampRegex = /\b(?:([0-9]+):)?([0-5][0-9]):([0-5][0-9])\b/g
+
+	for (const comment of commentHolder.querySelectorAll(".comentario-card .comentario-card-body > p")) {
+		// Skip if both spoilers and timestamps have already been processed
+		if (
+			comment.querySelector("span.crunchy-comments-spoiler-block") !== null &&
+			comment.querySelector("span.crunchy-comments-timestamp-block") !== null
+		) {
+			continue
+		}
+
+		let originalHTML = comment.innerHTML
+
+		// Replace Spoilers
+		originalHTML = originalHTML.replaceAll(
+			spoilerRegex,
+			(match) => `<span class="crunchy-comments-spoiler-block">${match.slice(2, -2).trim()}</span>`
+		)
+
+		// Replace Timestamps
+		originalHTML = originalHTML.replaceAll(
+			timestampRegex,
+			(match) => `<span class="crunchy-comments-timestamp-block">${match.trim()}</span>`
+		)
+
+		comment.innerHTML = originalHTML
+
+		// Add Event Listeners for Spoilers
+		comment.querySelectorAll("span.crunchy-comments-spoiler-block").forEach((spoiler) => {
+			spoiler.addEventListener("click", () => {
+				spoiler.classList.toggle("revealed")
+			})
+		})
+
+		// Add Event Listeners for Timestamps
+		comment.querySelectorAll("span.crunchy-comments-timestamp-block").forEach((timestamp) => {
+			timestamp.addEventListener("click", (e) => {
+				const regex = /\b(?:(?<h>[0-9]+):)?(?<m>[0-5][0-9]):(?<s>[0-5][0-9])\b/
+				const tsGroups = e.target.innerText.trim().match(regex)?.groups
+
+				if (!tsGroups) return
+
+				let [hours, minutes, seconds] = [tsGroups.h || 0, tsGroups.m, tsGroups.s].map((x) => parseInt(x))
+
+				seconds = (hours * 60 + minutes) * 60 + seconds
+
+				const el = document.querySelector("iframe.video-player") || document.getElementById("player0") || {}
+				if (el.scrollIntoView) {
+					el.scrollIntoView({
+						behavior: "smooth",
+						block: "end",
+						inline: "nearest",
+					})
+				}
+
+				const cssElement = document.getElementsByClassName("css-9pa8cd")[1]
+				if (cssElement && cssElement.click) {
+					cssElement.click()
+				}
+
+				const videoIframe = document.querySelector("iframe.video-player")
+				if (videoIframe && videoIframe.contentWindow) {
+					videoIframe.contentWindow.postMessage(
+						{
+							action: "renderTimestamp",
+							message: seconds,
+						},
+						"*"
+					)
+				}
+			})
+		})
+	}
+}
+
+let commentObserver = null
+
+// Reattach the MutationObserver to monitor comment changes
+const reattachCommentObserver = async () => {
+	const commentHolder = await getBodyElementEventually("comentario-comments .comentario-comments")
+	const onMutation = (mutationsList, observer) => {
+		observer.disconnect()
+
+		replaceFeaturesWithHtml(commentHolder)
+
+		if (commentObserver === observer) {
+			observer.observe(commentHolder, {
+				subtree: true,
+				childList: true,
+				characterData: true,
+			})
+		}
+	}
+
+	if (commentObserver !== null) commentObserver.disconnect()
+	commentObserver = new MutationObserver(onMutation)
+	replaceFeaturesWithHtml(commentHolder) // Initial replacement
+	commentObserver.observe(commentHolder, {
+		subtree: true,
+		childList: true,
+		characterData: true,
+	})
+}
+
+// Restore comments based on the current URL
+const restoreComments = () => {
+	const currentUrl = document.location.href
+
+	if (currentUrl.includes("watch") || currentUrl.includes("series"))
+		fetch("https://crunchy.404420.xyz/restore?url=" + currentUrl)
+			.then((response) => response.json())
+			.then((data) => {
+				const scrapeStatusElement = document.getElementById("scrape-status")
+				if (scrapeStatusElement) {
+					scrapeStatusElement.innerText = data.message || "Restoring old comments..."
+				}
+			})
+			.catch(() => {
+				const scrapeStatusElement = document.getElementById("scrape-status")
+				if (scrapeStatusElement) {
+					scrapeStatusElement.innerText = "Error restoring comments"
+				}
+			})
+}
+
+// Inject comentario-comments and status elements
+const checkAndInject = async () => {
+	const targetElement = document.querySelector(".app-body-wrapper")
+	if (targetElement) {
+		let oldElement = document.querySelector("comentario-comments")
+		let oldscrapeStatusElement = document.querySelector("#scrape-status")
+		if (oldElement) {
+			oldElement.remove()
+			oldscrapeStatusElement.remove()
+		}
+
+		let scrapeStatusElement = document.createElement("p")
+		scrapeStatusElement.id = "scrape-status"
+		scrapeStatusElement.className = "text--gq6o- text--is-l--iccTo expandable-section__text---00oG"
+		scrapeStatusElement.innerText = "Restoring archived comments..."
+		scrapeStatusElement.style =
+			"display: flex; justify-content: center; z-index: 999; max-width: fit-content; margin: 0 auto;"
+
+		let comentarioElement = document.createElement("comentario-comments")
+		comentarioElement.setAttribute("max-level", "5")
+		// It seems "page-id" does not have any effect, so changes are moved to comentario.js
+		targetElement.insertAdjacentElement("afterend", comentarioElement)
+		targetElement.insertAdjacentElement("afterend", scrapeStatusElement)
+
+		await reattachCommentObserver()
+	} else {
+		requestAnimationFrame(checkAndInject)
+	}
+}
+
+// Monitor URL changes and re-inject scripts as necessary
 const checkAndUpdate = () => {
 	window.addEventListener("popstate", async function (event) {
-		restoreComments();
-		await checkAndInject();
-	});
+		restoreComments()
+		await checkAndInject()
+	})
 
 	const bodyList = document.querySelector("body")
 
 	const observer = new MutationObserver(function (mutations) {
 		mutations.forEach(async function (mutation) {
-			if (oldHref != document.location.href) {
-				oldHref = document.location.href;
-				restoreComments();
-				await checkAndInject();
+			if (oldHref !== document.location.href) {
+				oldHref = document.location.href
+				restoreComments()
+				await checkAndInject()
 			}
 		})
 	})
@@ -44,187 +218,11 @@ const checkAndUpdate = () => {
 	observer.observe(bodyList, config)
 }
 
-const checkAndInject = async () => {
-	const targetElement = document.querySelector(".app-body-wrapper");
-	if (targetElement) {
-		let oldElement = document.querySelector("comentario-comments")
-		let oldscrapeStatusElement = document.querySelector("#scrape-status")
-		if (oldElement) {
-			oldElement.remove()
-			oldscrapeStatusElement.remove()
-		}
-		let scrapeStatusElement = document.createElement("p")
-		scrapeStatusElement.id = "scrape-status"
-		scrapeStatusElement.className = "text--gq6o- text--is-l--iccTo expandable-section__text---00oG"
-		scrapeStatusElement.innerText = "Restoring old comments..."
-		scrapeStatusElement.style =
-			"display: flex; justify-content: center; z-index: 999; max-width: fit-content; margin: 0 auto;"
-		let comentarioElement = document.createElement("comentario-comments")
-		comentarioElement.setAttribute("max-level", "5")
-		// It seems "page-id" does not have any effect, so changes are moved to comentario.js
-		targetElement.insertAdjacentElement("afterend", comentarioElement);
-		targetElement.insertAdjacentElement("afterend", scrapeStatusElement);
-
-		await reattachCommentObserver();
-	} else {
-		requestAnimationFrame(checkAndInject)
-	}
-}
-
-const restoreComments = () => {
-	const currentUrl = document.location.href
-
-	if (currentUrl.includes("watch") || currentUrl.includes("series"))
-		fetch("https://crunchy.404420.xyz/restore?url=" + currentUrl).then((response) => {
-			response.json().then((data) => {
-				scrapeStatusElement = document.getElementById("scrape-status")
-				try {
-					scrapeStatusElement.innerText = data.message
-				} catch (error) {
-					scrapeStatusElement.innerText = "Error restoring comments"
-				}
-			})
-		})
-}
-
-const renderTimestamp = async () => {
-	function replaceTextWithHtml(parent, observer) {
-		if (observer) observer.disconnect()
-
-		const regex = /\b(?:([0-9]+):)?([0-5][0-9]):([0-5][0-9])\b/g
-		parent.querySelectorAll(".comentario-card .comentario-card-body > p").forEach((textNode) => {
-			if (textNode.querySelector("span.crunchy-comments-timestamp-block") !== null) return
-			textNode.innerHTML = textNode.innerHTML.replaceAll(
-				regex,
-				(match) => `<span class="crunchy-comments-timestamp-block">${match.trim()}</span>`
-			)
-		})
-		if (observer)
-			observer.observe(targetElement, {
-				subtree: true,
-				characterData: true,
-				childList: true,
-			})
-	}
-	let targetElement = null
-
-	const timestampFinder = new MutationObserver((mutationsList, observer) => {
-		replaceTextWithHtml(targetElement, observer)
-	})
-
-	const targetElemFinder = new MutationObserver((_mutationList, observer) => {
-		targetElement = document.querySelector("comentario-comments .comentario-comments")
-		if (targetElement) {
-			observer.disconnect()
-
-			targetElement.addEventListener("click", (e) => {
-				if (!e.target.classList.contains("crunchy-comments-timestamp-block")) return
-				const regex = /\b(?:(?<h>[0-9]+):)?(?<m>[0-5][0-9]):(?<s>[0-5][0-9])\b/
-				let tsGroups = e.target.innerText.trim().match(regex).groups
-				let [hours, minutes, seconds] = [tsGroups.h || 0, tsGroups.m, tsGroups.s].map((x) => parseInt(x))
-
-				seconds = (hours * 60 + minutes) * 60 + seconds
-
-				const el = document.getElementsByTagName("iframe")[0] || document.querySelector("#player0") || {}
-				el.scrollIntoView({
-					behavior: "smooth",
-					block: "end",
-					inline: "nearest",
-				})
-				if (document.getElementsByClassName("css-9pa8cd")[1])
-					document.getElementsByClassName("css-9pa8cd")[1].click()
-
-				document.querySelector("iframe.video-player").contentWindow.postMessage(
-					{
-						action: "renderTimestamp",
-						message: seconds,
-					},
-					"*"
-				)
-			})
-
-			replaceTextWithHtml(targetElement, null)
-			timestampFinder.observe(targetElement, {
-				subtree: true,
-				characterData: true,
-				childList: true,
-			})
-		}
-	})
-	targetElement = document.querySelector("comentario-comments")
-	if (targetElement) {
-		targetElemFinder.observe(targetElement, {
-			subtree: true,
-			childList: true,
-		})
-	}
-}
-
-/* Waits for the first element that matches the selector to appear in the DOM */
-/** @returns Promise<Node> */
-const getBodyElementEventually = async function(selector) {
-	return new Promise((resolve) => {
-		function resolveIfPresent() {
-			const elem = document.querySelector(selector);
-			if (elem !== null) {
-				resolve(elem);
-			} else {
-				requestAnimationFrame(resolveIfPresent);
-			}
-		}
-		resolveIfPresent();
-	})
-};
-
-/* Takes the comment holder and replaces all spoilers with a span element that can be clicked to reveal the spoiler */
-const replaceSpoilersWithHtml = function(regex, commentHolder) {
-	for (const comment of commentHolder.querySelectorAll(".comentario-card .comentario-card-body > p:not(:has(span.crunchy-comments-spoiler-block))")) {
-		comment.innerHTML = comment.innerHTML.replaceAll(regex, (match) => `<span class="crunchy-comments-spoiler-block">${match.slice(2,match.length-2).trim()}</span>`);
-		comment.querySelectorAll("span.crunchy-comments-spoiler-block").forEach((spoiler) => {
-			spoiler.addEventListener("click", () => {
-				spoiler.classList.toggle("revealed");
-			});
-		});
-	}
-};
-
-const spoilerRegex = /\|\|.+?\|\|/gs;
-/* Renders features on the given comment holder */
-const renderFeatures = (commentHolder) => {
-	replaceSpoilersWithHtml(spoilerRegex, commentHolder);
-};
-
-let commentObserver = null;
-/* Reattaches the comment observer to the new comment holder */
-const reattachCommentObserver = async () => {
-	/* Render features on existing comments + rerender on changes */
-	const commentHolder = await getBodyElementEventually("comentario-comments .comentario-comments");
-	const onMutation = (mutationsList, observer) => {
-		observer.disconnect();
-
-		renderFeatures(commentHolder);
-
-		/* Only reobserve the comment holder if the observer has not already been replaced */
-		if (commentObserver === observer) {
-			observer.observe(commentHolder, {
-				subtree: true,
-				childList: true,
-				characterData: true
-			});
-		}
-	}
-
-	if (commentObserver !== null) commentObserver.disconnect();
-	commentObserver = new MutationObserver(onMutation);
-	onMutation(null, commentObserver);
-};
-
-// EntryPoint
+// Entry Point
 document.addEventListener("readystatechange", async (event) => {
 	if (document.readyState === "complete") {
-		restoreComments();
-		await checkAndInject();
-		checkAndUpdate();
-		renderTimestamp()
+		restoreComments()
+		await checkAndInject()
+		checkAndUpdate()
 	}
 })

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
     {
       "matches": ["https://www.crunchyroll.com/*"],
       "js": ["content-script.js"],
+      "css": ["styles.css"],
       "run_at": "document_end"
     }
   ],

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,45 @@
+.crunchy-comments-spoiler-block {
+    color: transparent;
+    background: rgba(127, 127, 127, 0.6);
+    padding: 0 4px;
+    border-radius: 4px;
+    vertical-align: middle;
+    cursor: pointer;
+    font-family: monospace;
+    position: relative;
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none; /* Standard syntax */
+    transition:
+            background 0.2s,
+            color 0.2s;
+}
+
+.crunchy-comments-spoiler-block:hover {
+    background: rgba(127, 127, 127, 0.8);
+}
+
+.crunchy-comments-spoiler-block.revealed {
+    background: rgba(127, 127, 127, 0.3);
+    color: revert;
+    -webkit-user-select: auto; /* Safari */
+    -ms-user-select: auto; /* IE 10 and IE 11 */
+    user-select: auto; /* Standard syntax */
+}
+
+.crunchy-comments-spoiler-block:hover::after {
+    content: "Spoiler (click to reveal)";
+    position: absolute;
+    color: white;
+    width: max-content;
+    background: gray;
+    padding: 0.1em 0.5em;
+    border-radius: 0.4em;
+    bottom: 100%;
+    transform: translate(-50%, -50%);
+    left: 50%;
+    font-size: x-small;
+}
+.crunchy-comments-spoiler-block.revealed:hover::after {
+    content: "Spoiler (click to hide)";
+}

--- a/styles.css
+++ b/styles.css
@@ -1,55 +1,55 @@
 .crunchy-comments-spoiler-block {
-    color: transparent;
-    background: rgba(127, 127, 127, 0.6);
-    padding: 0 4px;
-    border-radius: 4px;
-    vertical-align: middle;
-    cursor: pointer;
-    font-family: monospace;
-    position: relative;
-    -webkit-user-select: none; /* Safari */
-    -ms-user-select: none; /* IE 10 and IE 11 */
-    user-select: none; /* Standard syntax */
-    transition:
-            background 0.2s,
-            color 0.2s;
+	color: transparent;
+	background: rgba(127, 127, 127, 0.6);
+	padding: 0 4px;
+	border-radius: 4px;
+	vertical-align: middle;
+	cursor: pointer;
+	font-family: monospace;
+	position: relative;
+	-webkit-user-select: none; /* Safari */
+	-ms-user-select: none; /* IE 10 and IE 11 */
+	user-select: none; /* Standard syntax */
+	transition:
+		background 0.2s,
+		color 0.2s;
 }
 
 .crunchy-comments-spoiler-block:hover {
-    background: rgba(127, 127, 127, 0.8);
+	background: rgba(127, 127, 127, 0.8);
 }
 
 .crunchy-comments-spoiler-block.revealed {
-    background: rgba(127, 127, 127, 0.3);
-    color: revert;
-    -webkit-user-select: auto; /* Safari */
-    -ms-user-select: auto; /* IE 10 and IE 11 */
-    user-select: auto; /* Standard syntax */
+	background: rgba(127, 127, 127, 0.3);
+	color: revert;
+	-webkit-user-select: auto; /* Safari */
+	-ms-user-select: auto; /* IE 10 and IE 11 */
+	user-select: auto; /* Standard syntax */
 }
 
 .crunchy-comments-spoiler-block:hover::after {
-    content: "Spoiler (click to reveal)";
-    position: absolute;
-    color: white;
-    width: max-content;
-    background: gray;
-    padding: 0.1em 0.5em;
-    border-radius: 0.4em;
-    bottom: 100%;
-    transform: translate(-50%, -50%);
-    left: 50%;
-    font-size: x-small;
+	content: "Spoiler (click to reveal)";
+	position: absolute;
+	color: white;
+	width: max-content;
+	background: gray;
+	padding: 0.1em 0.5em;
+	border-radius: 0.4em;
+	bottom: 100%;
+	transform: translate(-50%, -50%);
+	left: 50%;
+	font-size: x-small;
 }
 .crunchy-comments-spoiler-block.revealed:hover::after {
-    content: "Spoiler (click to hide)";
+	content: "Spoiler (click to hide)";
 }
 .crunchy-comments-timestamp-block {
-    color: orange;
-    font-weight: bold;
-    background: rgba(255, 165, 0, 0.4);
-    padding: 0 4px;
-    font-size: 1.1rem;
-    border-radius: 4px;
-    vertical-align: middle;
-    cursor: pointer;
+	color: orange;
+	font-weight: bold;
+	background: rgba(255, 165, 0, 0.4);
+	padding: 0 4px;
+	font-size: 1.1rem;
+	border-radius: 4px;
+	vertical-align: middle;
+	cursor: pointer;
 }


### PR DESCRIPTION
### Description
Add Support for spoiler tags, as seen in discord: `||<not-empty>||`. 
Messages are scanned and found tags are replaced with a span, which hides the text by making it transparent and not selectable. 
There is a hover-'animation' and -popup indicating clickability, and on click the text-color reverts to its original, and the background becomes slightly lighter.  Another click hides the spoiler again.

### Design
- I put the call to `reattachCommentObserver()` directly into `checkAndInject()`
    - otherwise, it can be called in `checkAndUpdate()` and the `readystatechange` listener (I would also have to copy the `onRemoved()` function from my Tampermonkey script to wait for the actual element removal)
- I purposefully split the `renderFeatures()` and `replaceSpoilesWithHTML()` functions to allow additional features to be rendered if necessary (e.g. the timestamps or whatever 🤷)
- The pattern has changed from my initial message in the discord channel. It is now allowed to put spaces anywhere close to the `||` delimiters, as `|| ||` is also a valid spoiler in discord. (Initially, no spaces were allowed between the delimiter and the contained text)
- I am 60% certain that making `checkAndInject()` async was not strictly necessary, but it is probably good to keep the order of operations explicit 🤔

### Changelog
- add mutationObserver for the comment holder element
    - reattach it when comentario has been reset
    - wait for the reattachment process to be completed before continuing
- do spoiler rendering when comments change
    - spoiler syntax: `||<not-empty>||`
    - replaced with styled spans
    - with click listener for revealing the spoiler
- add some code comments
- add .idea Jetbrains-IDE config folder to gitignore

Greetings
PondusDev