### PR TITLE
[FIX] Status Element is not removed on redraw

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -237,9 +237,11 @@ const checkAndInject = async () => {
 	if (targetElement) {
 		let oldElement = document.querySelector("comentario-comments")
 		let oldscrapeStatusElement = document.querySelector("#scrape-status")
+		let oldStatusElement = document.querySelector("#app-status")
 		if (oldElement) {
 			oldElement.remove()
 			oldscrapeStatusElement.remove()
+			oldStatusElement.remove()
 		}
 
 		let statusElement = document.createElement("p")


### PR DESCRIPTION
### Description
When redrawing in `checkAndInject` we first have to remove all previously added elements. The removal of the status element was missing, and is added through this pull request.

### Changelog
- add removal of oldStatusElement to checkAndInject function

Greetings
PondusDev

---

fixes #11 