### PR TITLE
Scrape Status Element Fix

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -335,7 +335,7 @@ const checkAndInject = async () => {
 		scrapeStatusElement.className = "text--gq6o- text--is-l--iccTo expandable-section__text---00oG"
 		scrapeStatusElement.innerText = "Restoring archived comments..."
 		scrapeStatusElement.style =
-			"display: flex; justify-content: center; z-index: auto; max-width: fit-content; margin: 0 auto;"
+			"display: flex; justify-content: center; z-index: 1; max-width: fit-content; margin: 0 auto;"
 
 		let comentarioElement = document.createElement("comentario-comments")
 		comentarioElement.setAttribute("max-level", "5")


### PR DESCRIPTION
Makes that the text (especially the links) in the scrape-status element can be selected.
Before it was not possible because the div outside of the sign in button covers the scrape-status elemtent (in Firefox, I don't know about other browsers, but it should be the same).