### PR TITLE
fix: resolve race condition with page state change

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -410,7 +410,7 @@ window.addEventListener("locationchange", async () => {
 })
 
 // Entry Point
-document.addEventListener("readystatechange", async (event) => {
+async function init() {
 	if (document.readyState === "complete") {
 		Promise.all([restoreComments(), showServerStatus()]).catch((e) => console.error(e))
 		await checkAndInject()
@@ -418,4 +418,6 @@ document.addEventListener("readystatechange", async (event) => {
 
 		setInterval(showServerStatus, 300000)
 	}
-})
+}
+document.addEventListener("readystatechange", init)
+init()  // don't await this, it will block the extension from loading (I don't know why) [2025-03-07]


### PR DESCRIPTION
### Problem: 
- Copy link: https://www.crunchyroll.com/de/crunchylists
- Paste into new tab
- No CC
- Reload tab
- CC loads

---

### Cause:
- The ready-state is already `complete` when the extension is called

---

### Fix:
- Also test the ready-state once outside of the event listener.